### PR TITLE
fix: Space platform foundation recipe should take cables

### DIFF
--- a/prototypes/override.lua
+++ b/prototypes/override.lua
@@ -328,7 +328,7 @@ end
 if mods["space-age"] then
 	data.raw.recipe["space-platform-foundation"].ingredients = {
 		{ type = "item", name = "steel-plate", amount = 40 }, -- from 20
-		{ type = "item", name = "copper-plate", amount = 40 }, -- from 20
+		{ type = "item", name = "copper-cable", amount = 40 }, -- from 20
 	}
 end
 


### PR DESCRIPTION
The vanilla recipe takes cables so this ought to as well